### PR TITLE
Streams

### DIFF
--- a/py_to_proto/descriptor_to_message_class.py
+++ b/py_to_proto/descriptor_to_message_class.py
@@ -45,7 +45,7 @@ def descriptor_to_message_class(
         try:
             message_class = descriptor._concrete_class
         except (TypeError, SystemError, AttributeError):
-            # protobuf < 3.20 compatibility:
+            # protobuf version compatibility
             if hasattr(reflection.message_factory, "GetMessageClass"):
                 # Newer protobuf versions use GetMessageClass
                 message_class = reflection.message_factory.GetMessageClass(

--- a/py_to_proto/descriptor_to_message_class.py
+++ b/py_to_proto/descriptor_to_message_class.py
@@ -45,9 +45,7 @@ def descriptor_to_message_class(
         try:
             message_class = descriptor._concrete_class
         except (TypeError, SystemError, AttributeError):
-            message_class = reflection.message_factory.MessageFactory().GetPrototype(
-                descriptor
-            )
+            message_class = reflection.message_factory.GetMessageClass(descriptor)
 
         # Recursively add nested messages
         for nested_message_descriptor in descriptor.nested_types:

--- a/py_to_proto/descriptor_to_message_class.py
+++ b/py_to_proto/descriptor_to_message_class.py
@@ -45,7 +45,17 @@ def descriptor_to_message_class(
         try:
             message_class = descriptor._concrete_class
         except (TypeError, SystemError, AttributeError):
-            message_class = reflection.message_factory.GetMessageClass(descriptor)
+            # protobuf < 3.20 compatibility:
+            if hasattr(reflection.message_factory, "GetMessageClass"):
+                # Newer protobuf versions use GetMessageClass
+                message_class = reflection.message_factory.GetMessageClass(
+                    descriptor
+                )  # pragma: no cover
+            else:
+                # Older protobuf versions require creating an instance of a MessageFactory
+                message_class = (
+                    reflection.message_factory.MessageFactory().GetPrototype(descriptor)
+                )  # pragma: no cover
 
         # Recursively add nested messages
         for nested_message_descriptor in descriptor.nested_types:

--- a/py_to_proto/json_to_service.py
+++ b/py_to_proto/json_to_service.py
@@ -341,7 +341,6 @@ def _is_input_streaming(json_service_def: ServiceJsonType, method_name: str) -> 
     for method in rpcs_def:
         if method["name"] == method_name:
             return method.get("input_streaming", False)
-    return False
 
 
 def _is_output_streaming(json_service_def: ServiceJsonType, method_name: str) -> bool:
@@ -349,5 +348,4 @@ def _is_output_streaming(json_service_def: ServiceJsonType, method_name: str) ->
     rpcs_def = json_service["rpcs"]
     for method in rpcs_def:
         if method["name"] == method_name:
-            return method.get("input_streaming", False)
-    return False
+            return method.get("output_streaming", False)

--- a/py_to_proto/json_to_service.py
+++ b/py_to_proto/json_to_service.py
@@ -71,7 +71,7 @@ def json_to_service(
     *,
     descriptor_pool: Optional[_descriptor_pool.DescriptorPool] = None,
 ) -> GRPCService:
-    """Convert a JSON representation of an RPC service into a ServiceDescriptor.
+    """Convert a JSON representation of an RPC service into a GRPCService.
 
     Reference: https://jsontypedef.com/docs/jtd-in-5-minutes/
 
@@ -89,12 +89,12 @@ def json_to_service(
             message descriptors
 
     Returns:
-        groc_service:  GRPCService
+        grpc_service:  GRPCService
             The GRPCService container with the service descriptor and other associated
             grpc bits required to boot a server:
+            - Servicer registration function
             - Client stub class
             - Servicer base class
-            - Servicer registration function
     """
     # Ensure we have a valid service spec
     log.debug2("Validating service json")
@@ -201,8 +201,8 @@ def _service_descriptor_to_service(
 
     Returns:
         Type[google.protobuf.service.Service]
-            A new class with metaclass google.protobuf.service_reflection.GeneratedServiceType containing the methods
-            from the service_descriptor
+            A new class with metaclass google.protobuf.service_reflection.GeneratedServiceType
+            containing the methods from the service_descriptor
     """
     service_class = types.new_class(
         service_descriptor.name,
@@ -222,10 +222,11 @@ def _service_descriptor_to_client_stub(
     """Generates a new client stub class from the service descriptor
 
     Args:
-        service_descriptor (google.protobuf.descriptor.ServiceDescriptor):
+        service_descriptor:  google.protobuf.descriptor.ServiceDescriptor
             The ServiceDescriptor to generate a service interface for
-        service_descriptor_proto (google.protobuf.descriptor_pb2.ServiceDescriptorProto):
-            The descriptor proto for that service. This holds the I/O streaming information for each method
+        service_descriptor_proto:  google.protobuf.descriptor_pb2.ServiceDescriptorProto
+            The descriptor proto for that service. This holds the I/O streaming information
+            for each method
     """
 
     def _get_channel_func(
@@ -278,8 +279,10 @@ def _service_descriptor_to_server_registration_function(
     Args:
         service_descriptor:  google.protobuf.descriptor.ServiceDescriptor
             The ServiceDescriptor to generate a service interface for
-        service_descriptor_proto (google.protobuf.descriptor_pb2.ServiceDescriptorProto):
-            The descriptor proto for that service. This holds the I/O streaming information for each method
+        service_descriptor_proto:  google.protobuf.descriptor_pb2.ServiceDescriptorProto
+            The descriptor proto for that service. This holds the I/O streaming information
+            for each method
+
     Returns:
         function:  Server registration function to add service handlers to a server
     """

--- a/py_to_proto/json_to_service.py
+++ b/py_to_proto/json_to_service.py
@@ -1,14 +1,13 @@
 # Standard
-from typing import Callable, Dict, List, Optional, Set, Type
+from typing import Callable, Dict, List, Optional, Type
 import dataclasses
 import types
 
 # Third Party
-from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pb2
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import service
-from google.protobuf.descriptor import ServiceDescriptor
+from google.protobuf.descriptor import MethodDescriptor, ServiceDescriptor
 from google.protobuf.service import Service
 from google.protobuf.service_reflection import GeneratedServiceType
 import grpc
@@ -191,7 +190,7 @@ def _json_to_service_file_descriptor_proto(
 
 
 def _service_descriptor_to_service(
-    service_descriptor: _descriptor.ServiceDescriptor,
+    service_descriptor: ServiceDescriptor,
 ) -> Type[service.Service]:
     """Create a service class from a service descriptor
 
@@ -216,7 +215,7 @@ def _service_descriptor_to_service(
 
 
 def _service_descriptor_to_client_stub(
-    service_descriptor: _descriptor.ServiceDescriptor,
+    service_descriptor: ServiceDescriptor,
     service_descriptor_proto: descriptor_pb2.ServiceDescriptorProto,
 ) -> Type:
     """Generates a new client stub class from the service descriptor
@@ -271,7 +270,7 @@ def _service_descriptor_to_client_stub(
 
 
 def _service_descriptor_to_server_registration_function(
-    service_descriptor: _descriptor.ServiceDescriptor,
+    service_descriptor: ServiceDescriptor,
     service_descriptor_proto: descriptor_pb2.ServiceDescriptorProto,
 ) -> Callable[[Service, grpc.Server], None]:
     """Generates a server registration function from the service descriptor
@@ -320,6 +319,6 @@ def _service_descriptor_to_server_registration_function(
     return registration_function
 
 
-def _get_method_fullname(method: _descriptor.MethodDescriptor):
+def _get_method_fullname(method: MethodDescriptor):
     method_name_parts = method.full_name.split(".")
     return f"/{'.'.join(method_name_parts[:-1])}/{method_name_parts[-1]}"

--- a/py_to_proto/json_to_service.py
+++ b/py_to_proto/json_to_service.py
@@ -7,7 +7,7 @@ import types
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pb2
 from google.protobuf import descriptor_pool as _descriptor_pool
-from google.protobuf import message, service
+from google.protobuf import service
 from google.protobuf.descriptor import ServiceDescriptor
 from google.protobuf.service import Service
 from google.protobuf.service_reflection import GeneratedServiceType
@@ -38,8 +38,8 @@ SERVICE_JTD_SCHEMA = {
                             "output_type": {"type": "string"},
                         },
                         "optionalProperties": {
-                            "output_streaming": {"type": "boolean"},
-                            "input_streaming": {"type": "boolean"},
+                            "server_streaming": {"type": "boolean"},
+                            "client_streaming": {"type": "boolean"},
                         },
                     }
                 }
@@ -160,16 +160,13 @@ def _json_to_service_file_descriptor_proto(
         rpc_output_type = rpc_def["output_type"]
         output_descriptor = descriptor_pool.FindMessageTypeByName(rpc_output_type)
 
-        output_streaming = rpc_def.get("output_streaming", False)
-        input_streaming = rpc_def.get("input_streaming", False)
-
         method_descriptor_protos.append(
             descriptor_pb2.MethodDescriptorProto(
                 name=rpc_def["name"],
                 input_type=input_descriptor.full_name,
                 output_type=output_descriptor.full_name,
-                client_streaming=input_streaming,
-                server_streaming=output_streaming,
+                client_streaming=rpc_def.get("client_streaming", False),
+                server_streaming=rpc_def.get("server_streaming", False),
             )
         )
         imports.append(input_descriptor.file.name)

--- a/py_to_proto/json_to_service.py
+++ b/py_to_proto/json_to_service.py
@@ -1,5 +1,5 @@
 # Standard
-from typing import Callable, Dict, List, Optional, Type, Set
+from typing import Callable, Dict, List, Optional, Set, Type
 import dataclasses
 import types
 
@@ -8,7 +8,7 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pb2
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import message, service
-from google.protobuf.descriptor import ServiceDescriptor, MethodDescriptor
+from google.protobuf.descriptor import MethodDescriptor, ServiceDescriptor
 from google.protobuf.service import Service
 from google.protobuf.service_reflection import GeneratedServiceType
 import grpc
@@ -39,8 +39,8 @@ SERVICE_JTD_SCHEMA = {
                         },
                         "optionalProperties": {
                             "output_streaming": {"type": "boolean"},
-                            "input_streaming": {"type": "boolean"}
-                        }
+                            "input_streaming": {"type": "boolean"},
+                        },
                     }
                 }
             }
@@ -135,7 +135,7 @@ def json_to_service(
                 input_type=input_descriptor.full_name,
                 output_type=output_descriptor.full_name,
                 client_streaming=input_streaming,
-                server_streaming=output_streaming
+                server_streaming=output_streaming,
             )
         )
         imports.append(input_descriptor.file.name)
@@ -306,8 +306,5 @@ def _get_rpc_methods(service_descriptor: ServiceDescriptor) -> List[_RPCMethod]:
                 output_message_class=output_message_class,
             )
         )
-        print(method)
-        print(dir(method))
 
     return methods
-

--- a/py_to_proto/json_to_service.py
+++ b/py_to_proto/json_to_service.py
@@ -98,7 +98,9 @@ def json_to_service(
         raise ValueError("Invalid service json")
 
     # First get the descriptor:
-    service_descriptor = _json_to_service_descriptor(name, package, json_service_def, descriptor_pool=descriptor_pool)
+    service_descriptor = _json_to_service_descriptor(
+        name, package, json_service_def, descriptor_pool=descriptor_pool
+    )
     # And list of _RPCMethod bits for the client + registration function
     rpc_list = _get_rpc_methods(service_descriptor, json_service_def)
 
@@ -106,12 +108,19 @@ def json_to_service(
     client_stub = _service_descriptor_to_client_stub(service_descriptor, rpc_list)
 
     # And the registration function:
-    registration_function = _service_descriptor_to_server_registration_function(service_descriptor, rpc_list)
+    registration_function = _service_descriptor_to_server_registration_function(
+        service_descriptor, rpc_list
+    )
 
     # And service class!
     service_class = _service_descriptor_to_service(service_descriptor)
 
-    return GRPCService(descriptor=service_descriptor, service_class=service_class, client_stub_class=client_stub, registration_function=registration_function)
+    return GRPCService(
+        descriptor=service_descriptor,
+        service_class=service_class,
+        client_stub_class=client_stub,
+        registration_function=registration_function,
+    )
 
 
 def _json_to_service_descriptor(
@@ -268,6 +277,7 @@ def _service_descriptor_to_server_registration_function(
     Returns:
         function:  Server registration function to add service handlers to a server
     """
+
     def _get_handler(method: _RPCMethod):
         if method.input_streaming and method.output_streaming:
             return grpc.stream_stream_rpc_method_handler
@@ -295,7 +305,9 @@ def _service_descriptor_to_server_registration_function(
     return registration_function
 
 
-def _get_rpc_methods(service_descriptor: ServiceDescriptor, json_service_def: ServiceJsonType) -> List[_RPCMethod]:
+def _get_rpc_methods(
+    service_descriptor: ServiceDescriptor, json_service_def: ServiceJsonType
+) -> List[_RPCMethod]:
     """Get list of RPC methods from a service descriptor
 
     Args:
@@ -328,7 +340,7 @@ def _get_rpc_methods(service_descriptor: ServiceDescriptor, json_service_def: Se
                 input_message_class=input_message_class,
                 output_message_class=output_message_class,
                 input_streaming=_is_input_streaming(json_service_def, method.name),
-                output_streaming=_is_output_streaming(json_service_def, method.name)
+                output_streaming=_is_output_streaming(json_service_def, method.name),
             )
         )
 

--- a/py_to_proto/json_to_service.py
+++ b/py_to_proto/json_to_service.py
@@ -109,6 +109,9 @@ def json_to_service(
     service_fd_proto = _json_to_service_file_descriptor_proto(
         name, package, json_service_def, descriptor_pool=descriptor_pool
     )
+    assert (
+        len(service_fd_proto.service) == 1
+    ), f"File Descriptor {service_fd_proto.name} should only have one service"
     service_descriptor_proto = service_fd_proto.service[0]
 
     # Then put that in the pool to get the real descriptor back

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,6 +2,7 @@
 pytest>=6.2.5
 pytest-cov>=3.0.0
 pytest-xdist>=2.5.0
+tls_test_tools>=0.1.1
 
 # Round-trip proto compilation
 grpcio-tools>=1.46.3

--- a/tests/test_descriptor_to_file.py
+++ b/tests/test_descriptor_to_file.py
@@ -304,7 +304,7 @@ def test_descriptor_to_file_service_descriptor(temp_dpool):
             }
         },
         descriptor_pool=temp_dpool,
-    )
+    ).descriptor
     # TODO: type annotation fixup
     res = descriptor_to_file(service_descriptor)
     assert "service FooService {" in res
@@ -347,6 +347,6 @@ def test_descriptor_to_file_compilable_proto_with_service_descriptor(temp_dpool)
             }
         },
         descriptor_pool=temp_dpool,
-    )
+    ).descriptor
     res = descriptor_to_file(service_descriptor)
     assert compile_proto_module(res, imported_file_contents=imported_files)

--- a/tests/test_json_to_service.py
+++ b/tests/test_json_to_service.py
@@ -9,6 +9,7 @@ import types
 # Third Party
 import grpc
 import pytest
+import tls_test_tools
 
 # Local
 from py_to_proto import descriptor_to_message_class
@@ -311,12 +312,12 @@ def test_end_to_end_unary_unary_integration(foo_message, bar_message, foo_servic
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=50))
     registration_fn(Servicer(), server)
-    # TODO: find available port for these tests so they don't clobber each other
-    server.add_insecure_port("[::]:9002")
+    open_port = tls_test_tools.open_port()
+    server.add_insecure_port(f"[::]:{open_port}")
     server.start()
 
     # Create the client-side connection
-    chan = grpc.insecure_channel("localhost:9002")
+    chan = grpc.insecure_channel(f"localhost:{open_port}")
     my_stub = stub_class(chan)
     # nb: we'll set "foo" to the existence of "bar" to put asserts in the request handler
     input = foo_message(foo=True, bar=-9000)
@@ -367,11 +368,12 @@ def test_end_to_end_server_streaming_integration(foo_message, bar_message, temp_
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=50))
     registration_fn(Servicer(), server)
-    server.add_insecure_port("[::]:9001")
+    open_port = tls_test_tools.open_port()
+    server.add_insecure_port(f"[::]:{open_port}")
     server.start()
 
     # Create the client-side connection
-    chan = grpc.insecure_channel("localhost:9001")
+    chan = grpc.insecure_channel(f"localhost:{open_port}")
     my_stub = stub_class(chan)
     input = foo_message(foo=True, bar=-9000)
 
@@ -419,11 +421,12 @@ def test_end_to_end_client_streaming_integration(foo_message, bar_message, temp_
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=50))
     registration_fn(Servicer(), server)
-    server.add_insecure_port("[::]:9003")
+    open_port = tls_test_tools.open_port()
+    server.add_insecure_port(f"[::]:{open_port}")
     server.start()
 
     # Create the client-side connection
-    chan = grpc.insecure_channel("localhost:9003")
+    chan = grpc.insecure_channel(f"localhost:{open_port}")
     my_stub = stub_class(chan)
     input = iter(map(lambda i: foo_message(foo=True, bar=i), range(100)))
 
@@ -475,11 +478,12 @@ def test_end_to_end_client_and_server_streaming_integration(
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=50))
     registration_fn(Servicer(), server)
-    server.add_insecure_port("[::]:9004")
+    open_port = tls_test_tools.open_port()
+    server.add_insecure_port(f"[::]:{open_port}")
     server.start()
 
     # Create the client-side connection
-    chan = grpc.insecure_channel("localhost:9004")
+    chan = grpc.insecure_channel(f"localhost:{open_port}")
     my_stub = stub_class(chan)
     input = iter(map(lambda i: foo_message(foo=True, bar=i), range(100)))
 

--- a/tests/test_json_to_service.py
+++ b/tests/test_json_to_service.py
@@ -335,7 +335,7 @@ def test_end_to_end_unary_unary_integration(foo_message, bar_message, foo_servic
     server.stop(grace=0)
 
 
-def test_end_to_end_output_streaming_integration(foo_message, bar_message, temp_dpool):
+def test_end_to_end_server_streaming_integration(foo_message, bar_message, temp_dpool):
     service_json = {
         "service": {
             "rpcs": [
@@ -343,7 +343,7 @@ def test_end_to_end_output_streaming_integration(foo_message, bar_message, temp_
                     "name": "FooPredict",
                     "input_type": "foo.bar.Foo",
                     "output_type": "foo.bar.Bar",
-                    "output_streaming": True,
+                    "server_streaming": True,
                 }
             ]
         }
@@ -392,14 +392,14 @@ def test_end_to_end_output_streaming_integration(foo_message, bar_message, temp_
     server.stop(grace=0)
 
 
-def test_end_to_end_input_streaming_integration(foo_message, bar_message, temp_dpool):
+def test_end_to_end_client_streaming_integration(foo_message, bar_message, temp_dpool):
     service_json = {
         "service": {
             "rpcs": [
                 {
                     "name": "FooPredict",
                     "input_type": "foo.bar.Foo",
-                    "input_streaming": True,
+                    "client_streaming": True,
                     "output_type": "foo.bar.Bar",
                 }
             ]
@@ -443,7 +443,7 @@ def test_end_to_end_input_streaming_integration(foo_message, bar_message, temp_d
     server.stop(grace=0)
 
 
-def test_end_to_end_input_and_output_streaming_integration(
+def test_end_to_end_input_and_server_streaming_integration(
     foo_message, bar_message, temp_dpool
 ):
     service_json = {
@@ -452,9 +452,9 @@ def test_end_to_end_input_and_output_streaming_integration(
                 {
                     "name": "FooPredict",
                     "input_type": "foo.bar.Foo",
-                    "input_streaming": True,
+                    "client_streaming": True,
                     "output_type": "foo.bar.Bar",
-                    "output_streaming": True,
+                    "server_streaming": True,
                 }
             ]
         }

--- a/tests/test_json_to_service.py
+++ b/tests/test_json_to_service.py
@@ -443,7 +443,7 @@ def test_end_to_end_client_streaming_integration(foo_message, bar_message, temp_
     server.stop(grace=0)
 
 
-def test_end_to_end_input_and_server_streaming_integration(
+def test_end_to_end_client_and_server_streaming_integration(
     foo_message, bar_message, temp_dpool
 ):
     service_json = {

--- a/tests/test_json_to_service.py
+++ b/tests/test_json_to_service.py
@@ -3,9 +3,7 @@ Tests for json_to_service functions
 """
 # Standard
 from concurrent import futures
-from typing import Iterator
 import os
-import time
 import types
 
 # Third Party
@@ -14,9 +12,7 @@ import pytest
 
 # Local
 from py_to_proto import descriptor_to_message_class
-from py_to_proto.json_to_service import (
-    json_to_service,
-)
+from py_to_proto.json_to_service import json_to_service
 from py_to_proto.jtd_to_proto import jtd_to_proto
 
 ## Helpers #####################################################################
@@ -295,9 +291,7 @@ def test_service_descriptor_to_registration_function(foo_service):
     )
 
 
-def test_end_to_end_unary_unary_integration(
-    foo_message, bar_message, foo_service
-):
+def test_end_to_end_unary_unary_integration(foo_message, bar_message, foo_service):
     """Test a full grpc service integration"""
     registration_fn = foo_service.registration_function
     service_class = foo_service.service_class
@@ -341,9 +335,7 @@ def test_end_to_end_unary_unary_integration(
     server.stop(grace=0)
 
 
-def test_end_to_end_output_streaming_integration(
-    foo_message, bar_message, temp_dpool
-):
+def test_end_to_end_output_streaming_integration(foo_message, bar_message, temp_dpool):
     service_json = {
         "service": {
             "rpcs": [
@@ -400,9 +392,7 @@ def test_end_to_end_output_streaming_integration(
     server.stop(grace=0)
 
 
-def test_end_to_end_input_streaming_integration(
-    foo_message, bar_message, temp_dpool
-):
+def test_end_to_end_input_streaming_integration(foo_message, bar_message, temp_dpool):
     service_json = {
         "service": {
             "rpcs": [
@@ -488,7 +478,9 @@ def test_end_to_end_input_and_output_streaming_integration(
             for i in request_stream:
                 count += i.bar
 
-            return iter(map(lambda i: bar_message(boo=int(count), baz=True), range(100)))
+            return iter(
+                map(lambda i: bar_message(boo=int(count), baz=True), range(100))
+            )
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=50))
     registration_fn(Servicer(), server)

--- a/tests/test_json_to_service.py
+++ b/tests/test_json_to_service.py
@@ -16,9 +16,6 @@ import pytest
 from py_to_proto import descriptor_to_message_class
 from py_to_proto.json_to_service import (
     json_to_service,
-    service_descriptor_to_client_stub,
-    service_descriptor_to_server_registration_function,
-    service_descriptor_to_service,
 )
 from py_to_proto.jtd_to_proto import jtd_to_proto
 
@@ -66,7 +63,7 @@ def bar_message(temp_dpool):
 
 
 @pytest.fixture
-def foo_service_descriptor(temp_dpool, foo_message, bar_message):
+def foo_service(temp_dpool, foo_message, bar_message):
     """Service descriptor fixture"""
     # foo_message needs to have been defined for these input/output message to be valid
     service_json = {
@@ -111,15 +108,15 @@ def test_json_to_service_descriptor(temp_dpool, foo_message, bar_message):
         }
     }
     # _descriptor.ServiceDescriptor
-    service_descriptor = json_to_service(
+    service = json_to_service(
         package="foo.bar",
         name="FooService",
         json_service_def=service_json,
         descriptor_pool=temp_dpool,
     )
     # Validate message naming
-    assert service_descriptor.name == "FooService"
-    assert len(service_descriptor.methods) == 2
+    assert service.descriptor.name == "FooService"
+    assert len(service.descriptor.methods) == 2
 
 
 def test_duplicate_services_are_okay(temp_dpool, foo_message, bar_message):
@@ -142,20 +139,20 @@ def test_duplicate_services_are_okay(temp_dpool, foo_message, bar_message):
         }
     }
     # _descriptor.ServiceDescriptor
-    service_descriptor = json_to_service(
+    service = json_to_service(
         package="foo.bar",
         name="FooService",
         json_service_def=service_json,
         descriptor_pool=temp_dpool,
     )
 
-    another_service_descriptor = json_to_service(
+    another_service = json_to_service(
         package="foo.bar",
         name="FooService",
         json_service_def=service_json,
         descriptor_pool=temp_dpool,
     )
-    assert service_descriptor == another_service_descriptor
+    assert service.descriptor == another_service.descriptor
 
 
 ORIGINAL_SERVICE = {
@@ -251,17 +248,17 @@ def test_json_to_service_input_validation(temp_dpool, foo_message):
     assert "Invalid service json" in str(excinfo.value)
 
 
-def test_service_descriptor_to_service(foo_service_descriptor):
+def test_service_descriptor_to_service(foo_service):
     """Ensure that service class can be created from service descriptor"""
-    ServiceClass = service_descriptor_to_service(foo_service_descriptor)
+    ServiceClass = foo_service.service_class
 
     assert hasattr(ServiceClass, "FooPredict")
-    assert ServiceClass.__name__ == foo_service_descriptor.name
+    assert ServiceClass.__name__ == foo_service.descriptor.name
 
 
-def test_services_can_be_written_to_protobuf_files(foo_service_descriptor, tmp_path):
+def test_services_can_be_written_to_protobuf_files(foo_service, tmp_path):
     """Ensure that service class can be created from service descriptor"""
-    ServiceClass = service_descriptor_to_service(foo_service_descriptor)
+    ServiceClass = foo_service.service_class
 
     assert hasattr(ServiceClass, "to_proto_file")
     assert hasattr(ServiceClass, "write_proto_file")
@@ -273,24 +270,21 @@ def test_services_can_be_written_to_protobuf_files(foo_service_descriptor, tmp_p
         assert "service FooService {" in f.read()
 
 
-def test_service_descriptor_to_client_stub(foo_service_descriptor):
+def test_service_descriptor_to_client_stub(foo_service):
     """Ensure that client stub can be created from service descriptor"""
-
-    stub_class = service_descriptor_to_client_stub(foo_service_descriptor)
+    stub_class = foo_service.client_stub_class
     assert hasattr(stub_class(grpc.insecure_channel("localhost:9000")), "FooPredict")
     assert stub_class.__name__ == "FooServiceStub"
 
 
-def test_service_descriptor_to_registration_function(foo_service_descriptor):
+def test_service_descriptor_to_registration_function(foo_service):
     """Ensure that server registration function can be created from service descriptor"""
 
-    registration_fn = service_descriptor_to_server_registration_function(
-        foo_service_descriptor
-    )
+    registration_fn = foo_service.registration_function
     assert isinstance(registration_fn, types.FunctionType)
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=50))
-    service_class = service_descriptor_to_service(foo_service_descriptor)
+    service_class = foo_service.service_class
 
     registration_fn(service_class(), server)
 
@@ -302,14 +296,12 @@ def test_service_descriptor_to_registration_function(foo_service_descriptor):
 
 
 def test_end_to_end_unary_unary_integration(
-    foo_message, bar_message, foo_service_descriptor
+    foo_message, bar_message, foo_service
 ):
     """Test a full grpc service integration"""
-    registration_fn = service_descriptor_to_server_registration_function(
-        foo_service_descriptor
-    )
-    service_class = service_descriptor_to_service(foo_service_descriptor)
-    stub_class = service_descriptor_to_client_stub(foo_service_descriptor)
+    registration_fn = foo_service.registration_function
+    service_class = foo_service.service_class
+    stub_class = foo_service.client_stub_class
 
     # Define and start a gRPC service
     class Servicer(service_class):
@@ -349,7 +341,7 @@ def test_end_to_end_unary_unary_integration(
     server.stop(grace=0)
 
 
-def test_end_to_end_unary_output_streaming_integration(
+def test_end_to_end_output_streaming_integration(
     foo_message, bar_message, temp_dpool
 ):
     service_json = {
@@ -364,18 +356,16 @@ def test_end_to_end_unary_output_streaming_integration(
             ]
         }
     }
-    service_descriptor = json_to_service(
+    service = json_to_service(
         package="foo.bar",
         name="FooService",
         json_service_def=service_json,
         descriptor_pool=temp_dpool,
     )
 
-    registration_fn = service_descriptor_to_server_registration_function(
-        service_descriptor
-    )
-    service_class = service_descriptor_to_service(service_descriptor)
-    stub_class = service_descriptor_to_client_stub(service_descriptor)
+    registration_fn = service.registration_function
+    service_class = service.service_class
+    stub_class = service.client_stub_class
 
     class Servicer(service_class):
         """gRPC Service Impl"""
@@ -410,7 +400,7 @@ def test_end_to_end_unary_output_streaming_integration(
     server.stop(grace=0)
 
 
-def test_end_to_end_unary_input_streaming_integration(
+def test_end_to_end_input_streaming_integration(
     foo_message, bar_message, temp_dpool
 ):
     service_json = {
@@ -425,34 +415,26 @@ def test_end_to_end_unary_input_streaming_integration(
             ]
         }
     }
-    service_descriptor = json_to_service(
+    service = json_to_service(
         package="foo.bar",
         name="FooService",
         json_service_def=service_json,
         descriptor_pool=temp_dpool,
     )
 
-    registration_fn = service_descriptor_to_server_registration_function(
-        service_descriptor
-    )
-    service_class = service_descriptor_to_service(service_descriptor)
-    stub_class = service_descriptor_to_client_stub(service_descriptor)
+    registration_fn = service.registration_function
+    service_class = service.service_class
+    stub_class = service.client_stub_class
 
     class Servicer(service_class):
         """gRPC Service Impl"""
 
-        def FooPredict(self, request, context):
-            # Test that the `optionalProperty` "bar" of the request can be checked for existence
-            if request.foo:
-                assert request.HasField("bar")
-            else:
-                assert not request.HasField("bar")
-
+        def FooPredict(self, request_stream, context):
             count = 0
-            for i in request:
+            for i in request_stream:
                 count += i.bar
 
-            return bar_message(boo=count, baz=True)
+            return bar_message(boo=int(count), baz=True)
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=50))
     registration_fn(Servicer(), server)
@@ -462,17 +444,16 @@ def test_end_to_end_unary_input_streaming_integration(
     # Create the client-side connection
     chan = grpc.insecure_channel("localhost:9003")
     my_stub = stub_class(chan)
-    # nb: we'll set "foo" to the existence of "bar" to put asserts in the request handler
     input = iter(map(lambda i: foo_message(foo=True, bar=i), range(100)))
 
     # Make a gRPC call
-    response = my_stub.FooPredict(request=input)
+    response = my_stub.FooPredict(input)
     assert response.boo == 4950  # sum of range(100)
 
     server.stop(grace=0)
 
 
-def test_end_to_end_unary_input_and_output_streaming_integration(
+def test_end_to_end_input_and_output_streaming_integration(
     foo_message, bar_message, temp_dpool
 ):
     service_json = {
@@ -488,34 +469,26 @@ def test_end_to_end_unary_input_and_output_streaming_integration(
             ]
         }
     }
-    service_descriptor = json_to_service(
+    service = json_to_service(
         package="foo.bar",
         name="FooService",
         json_service_def=service_json,
         descriptor_pool=temp_dpool,
     )
 
-    registration_fn = service_descriptor_to_server_registration_function(
-        service_descriptor
-    )
-    service_class = service_descriptor_to_service(service_descriptor)
-    stub_class = service_descriptor_to_client_stub(service_descriptor)
+    registration_fn = service.registration_function
+    service_class = service.service_class
+    stub_class = service.client_stub_class
 
     class Servicer(service_class):
         """gRPC Service Impl"""
 
-        def FooPredict(self, request, context):
-            # Test that the `optionalProperty` "bar" of the request can be checked for existence
-            if request.foo:
-                assert request.HasField("bar")
-            else:
-                assert not request.HasField("bar")
-
+        def FooPredict(self, request_stream, context):
             count = 0
-            for i in request:
+            for i in request_stream:
                 count += i.bar
 
-            return iter(map(lambda i: bar_message(boo=count, baz=True), range(100)))
+            return iter(map(lambda i: bar_message(boo=int(count), baz=True), range(100)))
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=50))
     registration_fn(Servicer(), server)
@@ -525,12 +498,11 @@ def test_end_to_end_unary_input_and_output_streaming_integration(
     # Create the client-side connection
     chan = grpc.insecure_channel("localhost:9004")
     my_stub = stub_class(chan)
-    # nb: we'll set "foo" to the existence of "bar" to put asserts in the request handler
     input = iter(map(lambda i: foo_message(foo=True, bar=i), range(100)))
 
     # Make a gRPC call
     i = 0
-    for bar in my_stub.FooPredict(request=input):
+    for bar in my_stub.FooPredict(input):
         assert bar.boo == 4950  # sum of range(100)
         i += 1
     assert i == 100

--- a/tests/test_json_to_service.py
+++ b/tests/test_json_to_service.py
@@ -459,7 +459,7 @@ def test_end_to_end_client_and_server_streaming_integration(
 
 
 def test_multiple_rpcs_with_streaming(foo_message, bar_message, temp_dpool):
-
+    """ensuring that everything works with more than one endpoint"""
     service_json = {
         "service": {
             "rpcs": [
@@ -487,27 +487,17 @@ def test_multiple_rpcs_with_streaming(foo_message, bar_message, temp_dpool):
         descriptor_pool=temp_dpool,
     )
 
-    registration_fn = service.registration_function
-    service_class = service.service_class
-    stub_class = service.client_stub_class
-
-    class Servicer(service_class):
+    class Servicer(service.service_class):
         """gRPC Service Impl"""
 
         def BarPredict(self, request_stream, context):
-            count = 0
-            for i in request_stream:
-                count += i.bar
-
+            count = sum(i.bar for i in request_stream)
             return iter(
                 map(lambda i: bar_message(boo=int(count), baz=True), range(100))
             )
 
         def FooPredict(self, request_stream, context):
-            count = 0.0
-            for j in request_stream:
-                count += j.bar
-
+            count = sum(i.bar for i in request_stream)
             return iter(
                 map(lambda i: foo_message(foo=True, bar=float(count)), range(10))
             )

--- a/tests/test_json_to_service.py
+++ b/tests/test_json_to_service.py
@@ -1,14 +1,11 @@
 """
 Tests for json_to_service functions
 """
-import time
-from typing import Iterator
-
-from caikit.core.data_model.streams.data_stream import DataStream
-
 # Standard
 from concurrent import futures
+from typing import Iterator
 import os
+import time
 import types
 
 # Third Party
@@ -304,7 +301,9 @@ def test_service_descriptor_to_registration_function(foo_service_descriptor):
     )
 
 
-def test_end_to_end_unary_unary_integration(foo_message, bar_message, foo_service_descriptor):
+def test_end_to_end_unary_unary_integration(
+    foo_message, bar_message, foo_service_descriptor
+):
     """Test a full grpc service integration"""
     registration_fn = service_descriptor_to_server_registration_function(
         foo_service_descriptor
@@ -326,11 +325,12 @@ def test_end_to_end_unary_unary_integration(foo_message, bar_message, foo_servic
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=50))
     registration_fn(Servicer(), server)
-    server.add_insecure_port("[::]:9001")
+    # TODO: find available port for these tests so they don't clobber each other
+    server.add_insecure_port("[::]:9002")
     server.start()
 
     # Create the client-side connection
-    chan = grpc.insecure_channel("localhost:9001")
+    chan = grpc.insecure_channel("localhost:9002")
     my_stub = stub_class(chan)
     # nb: we'll set "foo" to the existence of "bar" to put asserts in the request handler
     input = foo_message(foo=True, bar=-9000)
@@ -349,7 +349,9 @@ def test_end_to_end_unary_unary_integration(foo_message, bar_message, foo_servic
     server.stop(grace=0)
 
 
-def test_end_to_end_unary_streaming_integration(foo_message, bar_message, temp_dpool):
+def test_end_to_end_unary_output_streaming_integration(
+    foo_message, bar_message, temp_dpool
+):
     service_json = {
         "service": {
             "rpcs": [
@@ -378,18 +380,6 @@ def test_end_to_end_unary_streaming_integration(foo_message, bar_message, temp_d
     class Servicer(service_class):
         """gRPC Service Impl"""
 
-        def to_proto(self, i: int) -> bar_message:
-            return bar_message(boo=i, baz=True)
-
-        def some_generator(self, n) -> Iterator[int]:
-            for i in range(n):
-                yield i
-                time.sleep(0.01)
-
-        def some_model_run(self) -> DataStream[int]:
-            my_output_stream = DataStream(self.some_generator, 100)
-            return my_output_stream
-
         def FooPredict(self, request, context):
             # Test that the `optionalProperty` "bar" of the request can be checked for existence
             if request.foo:
@@ -397,11 +387,7 @@ def test_end_to_end_unary_streaming_integration(foo_message, bar_message, temp_d
             else:
                 assert not request.HasField("bar")
 
-            datastream = self.some_model_run()
-
-            return iter(datastream.map(self.to_proto))
-            # for thing in datastream:
-            #     yield self.to_proto(thing)
+            return iter(map(lambda i: bar_message(boo=i, baz=True), range(100)))
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=50))
     registration_fn(Servicer(), server)
@@ -418,6 +404,134 @@ def test_end_to_end_unary_streaming_integration(foo_message, bar_message, temp_d
     i = 0
     for bar in my_stub.FooPredict(request=input):
         assert bar.boo == i
+        i += 1
+    assert i == 100
+
+    server.stop(grace=0)
+
+
+def test_end_to_end_unary_input_streaming_integration(
+    foo_message, bar_message, temp_dpool
+):
+    service_json = {
+        "service": {
+            "rpcs": [
+                {
+                    "name": "FooPredict",
+                    "input_type": "foo.bar.Foo",
+                    "input_streaming": True,
+                    "output_type": "foo.bar.Bar",
+                }
+            ]
+        }
+    }
+    service_descriptor = json_to_service(
+        package="foo.bar",
+        name="FooService",
+        json_service_def=service_json,
+        descriptor_pool=temp_dpool,
+    )
+
+    registration_fn = service_descriptor_to_server_registration_function(
+        service_descriptor
+    )
+    service_class = service_descriptor_to_service(service_descriptor)
+    stub_class = service_descriptor_to_client_stub(service_descriptor)
+
+    class Servicer(service_class):
+        """gRPC Service Impl"""
+
+        def FooPredict(self, request, context):
+            # Test that the `optionalProperty` "bar" of the request can be checked for existence
+            if request.foo:
+                assert request.HasField("bar")
+            else:
+                assert not request.HasField("bar")
+
+            count = 0
+            for i in request:
+                count += i.bar
+
+            return bar_message(boo=count, baz=True)
+
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=50))
+    registration_fn(Servicer(), server)
+    server.add_insecure_port("[::]:9003")
+    server.start()
+
+    # Create the client-side connection
+    chan = grpc.insecure_channel("localhost:9003")
+    my_stub = stub_class(chan)
+    # nb: we'll set "foo" to the existence of "bar" to put asserts in the request handler
+    input = iter(map(lambda i: foo_message(foo=True, bar=i), range(100)))
+
+    # Make a gRPC call
+    response = my_stub.FooPredict(request=input)
+    assert response.boo == 4950  # sum of range(100)
+
+    server.stop(grace=0)
+
+
+def test_end_to_end_unary_input_and_output_streaming_integration(
+    foo_message, bar_message, temp_dpool
+):
+    service_json = {
+        "service": {
+            "rpcs": [
+                {
+                    "name": "FooPredict",
+                    "input_type": "foo.bar.Foo",
+                    "input_streaming": True,
+                    "output_type": "foo.bar.Bar",
+                    "output_streaming": True,
+                }
+            ]
+        }
+    }
+    service_descriptor = json_to_service(
+        package="foo.bar",
+        name="FooService",
+        json_service_def=service_json,
+        descriptor_pool=temp_dpool,
+    )
+
+    registration_fn = service_descriptor_to_server_registration_function(
+        service_descriptor
+    )
+    service_class = service_descriptor_to_service(service_descriptor)
+    stub_class = service_descriptor_to_client_stub(service_descriptor)
+
+    class Servicer(service_class):
+        """gRPC Service Impl"""
+
+        def FooPredict(self, request, context):
+            # Test that the `optionalProperty` "bar" of the request can be checked for existence
+            if request.foo:
+                assert request.HasField("bar")
+            else:
+                assert not request.HasField("bar")
+
+            count = 0
+            for i in request:
+                count += i.bar
+
+            return iter(map(lambda i: bar_message(boo=count, baz=True), range(100)))
+
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=50))
+    registration_fn(Servicer(), server)
+    server.add_insecure_port("[::]:9004")
+    server.start()
+
+    # Create the client-side connection
+    chan = grpc.insecure_channel("localhost:9004")
+    my_stub = stub_class(chan)
+    # nb: we'll set "foo" to the existence of "bar" to put asserts in the request handler
+    input = iter(map(lambda i: foo_message(foo=True, bar=i), range(100)))
+
+    # Make a gRPC call
+    i = 0
+    for bar in my_stub.FooPredict(request=input):
+        assert bar.boo == 4950  # sum of range(100)
         i += 1
     assert i == 100
 


### PR DESCRIPTION
Closes #50 

This PR adds streaming support to `json_to_service`. The `client_streaming` and `server_streaming` optional properties are added to the JTD spec for the objects in the `rpcs` list, to match `MethodDescriptorProto`. If these are not set, it's assumed they are `False` (no streaming).

A fun quirk is that the [micropb](https://github.com/protocolbuffers/upb) package that powers python protobuf does not retain the `client_streaming` and `server_streaming` flags in the `MethodDescriptor` objects like the slower, pure python implementation does. (Presumably this is because protobuf doesn't care about them since it does not provide the client and server implementations, grpc does ...?). This means our previous interaction flow of 
1. Get the `ServiceDescriptor`
2. Pass the `ServiceDescriptor` around to get a client stub, service class, and registration function
no longer works because the descriptor does not retain the necessary information, you still need the `ServiceDescriptorProto` that has the streaming flags. So this PR breaks the `json_to_service` API to instead return all of those things packaged up into a little `GRPCService` dataclass.

I'm open to not breaking the `json_to_service` api and instead providing a new `json_to_grpc_service` or something that does this, but that would be pretty awkward since you couldn't have streaming support with the old style api.