### PR TITLE
:white_check_mark: Add duplicate client and server streaming tests

### DIFF
--- a/py_to_proto/utils.py
+++ b/py_to_proto/utils.py
@@ -243,7 +243,7 @@ def _are_same_method_descriptor(
         return False
     if not _are_types_similar(d1_method.output_type, d2_method.output_type):
         return False
-    # TODO: Add the ability for `json_to_service` to set options + streaming settings.
+    # TODO: Add the ability for `json_to_service` to set options
     # Then we can test this!
     if d1_method.options != d2_method.options:
         log.debug(  # pragma: no cover
@@ -251,9 +251,9 @@ def _are_same_method_descriptor(
         )
         return False  # pragma: no cover
     if d1_method.client_streaming != d2_method.client_streaming:
-        return False  # pragma: no cover
+        return False
     if d1_method.server_streaming != d2_method.server_streaming:
-        return False  # pragma: no cover
+        return False
     return True
 
 

--- a/tests/test_json_to_service.py
+++ b/tests/test_json_to_service.py
@@ -92,14 +92,13 @@ def _test_server_client(
     grpc_service: GRPCService,
     servicer_impl_class: Type,
 ):
-    # boot the server
+    # Boot the server
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=50))
     grpc_service.registration_function(servicer_impl_class(), server)
     open_port = tls_test_tools.open_port()
     server.add_insecure_port(f"[::]:{open_port}")
     server.start()
 
-    # open a client connection
     # Create the client-side connection
     chan = grpc.insecure_channel(f"localhost:{open_port}")
     my_stub = grpc_service.client_stub_class(chan)
@@ -220,6 +219,30 @@ INVALID_DUPLICATE_SERVICES = [
                     "name": "FooTrain",
                     "input_type": "foo.bar.Foo",
                     "output_type": "foo.bar.Foo",  # Different output
+                }
+            ]
+        }
+    },
+    {
+        "service": {
+            "rpcs": [
+                {
+                    "name": "FooTrain",
+                    "input_type": "foo.bar.Foo",
+                    "output_type": "foo.bar.Bar",
+                    "client_streaming": True,  # Different client streaming
+                }
+            ]
+        }
+    },
+    {
+        "service": {
+            "rpcs": [
+                {
+                    "name": "FooTrain",
+                    "input_type": "foo.bar.Foo",
+                    "output_type": "foo.bar.Bar",
+                    "server_streaming": True,  # Different server streaming
                 }
             ]
         }


### PR DESCRIPTION
Addendum to #51 where client and server streaming support was added through `json_to_service`. These lines are now testable.