### PR TITLE
✨ add list support to union

### DIFF
--- a/py_to_proto/dataclass_to_proto.py
+++ b/py_to_proto/dataclass_to_proto.py
@@ -254,7 +254,9 @@ class DataclassConverter(ConverterBase):
                 res_type = self._resolve_wrapped_type(arg)
                 # handle list type separately
                 if get_origin(res_type) is list:
-                    assert get_args(res_type), f"List {arg} does not have any arguments"
+                    assert get_args(
+                        res_type
+                    ), f"List {arg} does not have any type argument"
                     field_type = get_args(res_type)[0]
                     oneof_field_name = oneof_field_name or (
                         f"{field_def.name}_{str(field_type.__name__)}_sequence".lower()

--- a/tests/test_dataclass_to_proto.py
+++ b/tests/test_dataclass_to_proto.py
@@ -320,7 +320,24 @@ def test_dataclass_to_proto_repeated_enum(temp_dpool):
     assert bar_fld.enum_type == foo_desc
 
 
+def test_dataclass_to_proto_oneof_no_type_in_list_raises(temp_dpool):
+    """If the List has no type argument, then exception is raised"""
+
+    @dataclass
+    class Baz:
+        baz: Union[
+            Annotated[List, OneofField("baz_str_sequence")],
+            Annotated[List, OneofField("baz_int_sequence")],
+        ]
+
+    with pytest.raises(AssertionError):
+        dataclass_to_proto("foo.bar", Baz, descriptor_pool=temp_dpool)
+
+
 def test_dataclass_to_proto_oneof_annotated_list_primitives(temp_dpool):
+    """Make sure that a oneof with lists of primitive fields within annotations
+    works correctly"""
+
     @dataclass
     class Baz:
         baz: Union[


### PR DESCRIPTION
## Description
If we now have a `Dataclass` like this:
```
@dataclass
class Baz:
    baz: Union[List[str], List[int]]
```

It takes each `List[x]` type and wraps that in a `sub-message` with a single repeated `x` field, then use that `sub-type` in the parent `oneof`

The corresponding `proto` file looks like this:

```

/*------------------------------------------------------------------------------
 * AUTO GENERATED
 *----------------------------------------------------------------------------*/

syntax = "proto3";
package foo.bar;


/*-- MESSAGES ----------------------------------------------------------------*/

message Baz {

  /*-- nested messages --*/
  message StrSequence {

    /*-- fields --*/
    repeated string values = 1;
  }
  message IntSequence {

    /*-- fields --*/
    repeated int64 values = 1;
  }

  /*-- fields --*/

  /*-- oneofs --*/
  oneof baz {
    foo.bar.Baz.StrSequence baz_strsequence = 1;
    foo.bar.Baz.IntSequence baz_intsequence = 2;
  }
}
```

Connected to: https://github.com/caikit/caikit/issues/198