### PR TITLE
🐛 fix multiple union list bug

### DIFF
--- a/py_to_proto/dataclass_to_proto.py
+++ b/py_to_proto/dataclass_to_proto.py
@@ -262,7 +262,7 @@ class DataclassConverter(ConverterBase):
                         f"{field_def.name}_{str(field_type.__name__)}_sequence".lower()
                     )
                     arg = dataclasses.make_dataclass(
-                        f"{str(field_type.__name__).capitalize()}Sequence",
+                        f"{field_def.name.capitalize()}{str(field_type.__name__).capitalize()}Sequence",
                         [("values", List[field_type])],
                     )
                 elif oneof_field_name is None:


### PR DESCRIPTION
This PR attempts to fix multiple unions of list issue. This PR makes it such that 
`baz: Union[List[str], List[int]]` gets converted to `BazIntSequence` and `BazStrSequence` (instead of `IntSequence` and `StrSequence`) so that there are no more name collisions if there are multiple unions within the same `dataclass`.

related to https://github.com/caikit/caikit/issues/277