### PR TITLE
ServiceStreamingDescriptor: Support streaming rpcs in descriptor_to_file

### DIFF
--- a/tests/test_descriptor_to_file.py
+++ b/tests/test_descriptor_to_file.py
@@ -296,10 +296,29 @@ def test_descriptor_to_file_service_descriptor(temp_dpool):
             "service": {
                 "rpcs": [
                     {
-                        "name": "FooPredict",
+                        "name": "FooPredictUnaryUnary",
                         "input_type": "foo.bar.Foo",
                         "output_type": "foo.bar.Foo",
-                    }
+                    },
+                    {
+                        "name": "FooPredictUnaryStream",
+                        "input_type": "foo.bar.Foo",
+                        "output_type": "foo.bar.Foo",
+                        "server_streaming": True,
+                    },
+                    {
+                        "name": "FooPredictStreamUnary",
+                        "input_type": "foo.bar.Foo",
+                        "output_type": "foo.bar.Foo",
+                        "client_streaming": True,
+                    },
+                    {
+                        "name": "FooPredictStreamStream",
+                        "input_type": "foo.bar.Foo",
+                        "output_type": "foo.bar.Foo",
+                        "client_streaming": True,
+                        "server_streaming": True,
+                    },
                 ]
             }
         },
@@ -308,6 +327,13 @@ def test_descriptor_to_file_service_descriptor(temp_dpool):
     # TODO: type annotation fixup
     res = descriptor_to_file(service_descriptor)
     assert "service FooService {" in res
+    assert "rpc FooPredictUnaryUnary(foo.bar.Foo) returns (foo.bar.Foo)" in res
+    assert "rpc FooPredictUnaryStream(foo.bar.Foo) returns (stream foo.bar.Foo)" in res
+    assert "rpc FooPredictStreamUnary(stream foo.bar.Foo) returns (foo.bar.Foo)" in res
+    assert (
+        "rpc FooPredictStreamStream(stream foo.bar.Foo) returns (stream foo.bar.Foo)"
+        in res
+    )
 
 
 def test_descriptor_to_file_compilable_proto_with_service_descriptor(temp_dpool):


### PR DESCRIPTION
## Description

When serializing an in-memory `MethodDescriptor` to a `.proto` file, include `client_streaming` and `server_streaming` information.

NOTE: This is tricky because these fields are [held in the underlying C structure](https://github.com/protocolbuffers/upb/blob/main/upb/util/def_to_proto.c#L471), but are [not exposed in the in-memory python class](https://github.com/protocolbuffers/upb/blob/main/python/descriptor.c#L1334). To work around this, we serialize to the `descriptor_pb2.MethodDescriptor` object to pull the information.