### PR TITLE
🐛 append package name to file descriptors

### DIFF
--- a/py_to_proto/converter_base.py
+++ b/py_to_proto/converter_base.py
@@ -114,7 +114,7 @@ class ConverterBase(Generic[T], abc.ABC):
         # Create the FileDescriptorProto with all messages
         log.debug("Creating FileDescriptorProto")
         fd_proto = descriptor_pb2.FileDescriptorProto(
-            name=f"{name.lower()}.proto",
+            name=f"{package}.{name.lower()}.proto",
             package=package,
             syntax="proto3",
             dependency=sorted(list(self.imports)),

--- a/tests/test_dataclass_to_proto.py
+++ b/tests/test_dataclass_to_proto.py
@@ -684,7 +684,6 @@ def test_dataclass_to_proto_duplicate_proto_files(temp_dpool):
         foo: int
         bar: str
 
-
     desc1 = dataclass_to_proto(
         "foo.bar", Foo, descriptor_pool=temp_dpool, validate=True
     )

--- a/tests/test_dataclass_to_proto.py
+++ b/tests/test_dataclass_to_proto.py
@@ -700,10 +700,6 @@ def test_dataclass_to_proto_duplicate_proto_files(temp_dpool):
         assert desc.fields_by_name["foo"].type == desc.fields_by_name["foo"].TYPE_INT64
         assert desc.fields_by_name["bar"].type == desc.fields_by_name["bar"].TYPE_STRING
 
-    # This should raise since we're not changing the package name here
-    with pytest.raises(TypeError):
-        dataclass_to_proto("foo.bar", Foo, descriptor_pool=temp_dpool, validate=True)
-
 
 ## Error Cases #################################################################
 

--- a/tests/test_dataclass_to_proto.py
+++ b/tests/test_dataclass_to_proto.py
@@ -684,10 +684,6 @@ def test_dataclass_to_proto_duplicate_proto_files(temp_dpool):
         foo: int
         bar: str
 
-    @dataclass
-    class Foo:
-        foo: int
-        bar: str
 
     desc1 = dataclass_to_proto(
         "foo.bar", Foo, descriptor_pool=temp_dpool, validate=True

--- a/tests/test_dataclass_to_proto.py
+++ b/tests/test_dataclass_to_proto.py
@@ -676,6 +676,35 @@ def test_dataclass_to_proto_optional_field(temp_dpool):
     assert baz_fld.type == _descriptor.FieldDescriptor.TYPE_STRING
 
 
+def test_dataclass_to_proto_duplicate_proto_files(temp_dpool):
+    """Make sure a dataclass with the same name dataclass works as expected"""
+
+    @dataclass
+    class Foo:
+        foo: int
+        bar: str
+
+    @dataclass
+    class Foo:
+        foo: int
+        bar: str
+
+    desc1 = dataclass_to_proto(
+        "foo.bar", Foo, descriptor_pool=temp_dpool, validate=True
+    )
+    # this should work since we are declaring a different package name
+    desc2 = dataclass_to_proto(
+        "foo.baz", Foo, descriptor_pool=temp_dpool, validate=True
+    )
+    for desc in [desc1, desc2]:
+        assert desc.fields_by_name["foo"].type == desc.fields_by_name["foo"].TYPE_INT64
+        assert desc.fields_by_name["bar"].type == desc.fields_by_name["bar"].TYPE_STRING
+
+    # This should raise since we're not changing the package name here
+    with pytest.raises(TypeError):
+        dataclass_to_proto("foo.bar", Foo, descriptor_pool=temp_dpool, validate=True)
+
+
 ## Error Cases #################################################################
 
 

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -830,7 +830,15 @@ def test_protoc_collision_same_def(temp_dpool):
         validate_jtd=True,
         descriptor_pool=temp_dpool,
     )
-    temp_dpool.AddSerializedFile(protoc_sample)
+    ### NOTE: This used to work before, but now raises an error
+    # because of the fact that we now save file descriptors
+    # with package name appended to them to disambiguate between
+    # other proto files with the same name but different package
+
+    # So now, OuterMessage exists within a file called
+    # test.jtd_to_proto.outermessage.proto hence it complains
+    with pytest.raises(TypeError):
+        temp_dpool.AddSerializedFile(protoc_sample)
 
 
 def test_map_to_message_reference(temp_dpool):

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -821,8 +821,9 @@ def test_type_names_are_fully_qualified_with_multiple_packages(temp_dpool):
 
 def test_protoc_collision_same_def(temp_dpool):
     """Test that if we do jtd_to_proto -> protoc with the same underlying file name, it is okay."""
-    # Happy because the file is named outermessage.proto, so we can find it!
-    protoc_sample = b'\n\x12outermessage.proto\x12\x11test.jtd_to_proto"!\n\x0cOuterMessage\x12\x11\n\tprimitive\x18\x01 \x01(\tb\x06proto3'
+    # Happy because the file is named test.jtd_to_proto.outermessage.proto, so we can find it!
+    # Note: The file was earlier named outermessage.proto but now we prefix the name with the package name
+    protoc_sample = b'\n$test.jtd_to_proto.outermessage.proto\x12\x11test.jtd_to_proto"!\n\x0cOuterMessage\x12\x11\n\tprimitive\x18\x01 \x01(\tb\x06proto3'
     jtd_to_proto(
         name="OuterMessage",
         package="test.jtd_to_proto",
@@ -830,15 +831,7 @@ def test_protoc_collision_same_def(temp_dpool):
         validate_jtd=True,
         descriptor_pool=temp_dpool,
     )
-    ### NOTE: This used to work before, but now raises an error
-    # because of the fact that we now save file descriptors
-    # with package name appended to them to disambiguate between
-    # other proto files with the same name but different package
-
-    # So now, OuterMessage exists within a file called
-    # test.jtd_to_proto.outermessage.proto hence it complains
-    with pytest.raises(TypeError):
-        temp_dpool.AddSerializedFile(protoc_sample)
+    temp_dpool.AddSerializedFile(protoc_sample)
 
 
 def test_map_to_message_reference(temp_dpool):


### PR DESCRIPTION
Ideally, same name `proto` files with different package names should be allowed to coexist within the same descriptor pool. But the reason it doesn't work right now is while checking for `_are_same_file_descriptors`, we check if the package name for `proto` files is the same or not. If it's not, we error out saying the files have different content but have the same name.  

This PR ensures they can coexist by appending `package name` to the file descriptor name so that the 2 file descriptors are named different now for the same name but different package `proto` file