### PR TITLE
🐛 fix order of docker stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN ./scripts/publish.sh
 # This phase installs the indicated version from PyPi and runs the unit tests
 # against the installed version.
 ##
-FROM base as release_test
+FROM release as release_test
 ARG RELEASE_VERSION
 ARG RELEASE_DRY_RUN
 COPY ./tests /src/tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,13 +50,17 @@ ARG PYPI_TOKEN
 ARG RELEASE_VERSION
 ARG RELEASE_DRY_RUN
 RUN ./scripts/publish.sh
+RUN touch completed.txt
 
 ## Release Test ################################################################
 #
 # This phase installs the indicated version from PyPi and runs the unit tests
 # against the installed version.
 ##
-FROM release as release_test
+FROM base as release_test
+# Copy a random file from the release phase just
+# to ensure release_test runs _after_ release
+COPY --from=release completed.txt .
 ARG RELEASE_VERSION
 ARG RELEASE_DRY_RUN
 COPY ./tests /src/tests


### PR DESCRIPTION
Essentially the `release_test` should happen after release to control the order